### PR TITLE
Add .NET 10 support to core utilities packages

### DIFF
--- a/Softalleys.Utilities.Commands/README.md
+++ b/Softalleys.Utilities.Commands/README.md
@@ -1,6 +1,6 @@
 # Softalleys.Utilities.Commands
 
-Lightweight command pipeline for .NET 8/9 with validators, processors, handlers, optional post-actions, and DI scanning. Designed to pair with Softalleys.Utilities.Events and Softalleys.Utilities.Queries.
+Lightweight command pipeline for .NET 8/9/10 with validators, processors, handlers, optional post-actions, and DI scanning. Designed to pair with Softalleys.Utilities.Events and Softalleys.Utilities.Queries.
 
 ## Concepts
 
@@ -62,7 +62,7 @@ public class CreateCategoryValidator : ICommandValidator<CreateCategoryCommand, 
     public Task<CreateCategoryResult> ValidateAsync(CreateCategoryCommand cmd, CancellationToken ct = default)
     # Softalleys.Utilities.Commands
 
-    Lightweight command pipeline for .NET (net8/net9) with validators, processors, default handler, post-actions and DI scanning.
+    Lightweight command pipeline for .NET (net8/net9/net10) with validators, processors, default handler, post-actions and DI scanning.
 
     Key features
     - ICommand/ICommandHandler pipeline with validation and processing stages

--- a/Softalleys.Utilities.Commands/Softalleys.Utilities.Commands.csproj
+++ b/Softalleys.Utilities.Commands/Softalleys.Utilities.Commands.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -23,6 +23,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Softalleys.Utilities.Events/README.md
+++ b/Softalleys.Utilities.Events/README.md
@@ -1,6 +1,6 @@
 # Softalleys.Utilities.Events
 
-A lightweight, flexible event-driven architecture library for .NET applications. This library provides a robust event handling system with proper dependency injection scope management, pre/post processing pipelines, and support for both scoped and singleton handler lifecycles.
+A lightweight, flexible event-driven architecture library for .NET applications. This library provides a robust event handling system with proper dependency injection scope management, pre/post processing pipelines, and support for both scoped and singleton handler lifecycles. It targets .NET 8, .NET 9, and .NET 10 so you can adopt the latest runtime as soon as it lands.
 
 ## ✨ Features
 

--- a/Softalleys.Utilities.Events/Softalleys.Utilities.Events.csproj
+++ b/Softalleys.Utilities.Events/Softalleys.Utilities.Events.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -19,12 +19,17 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" />
-  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.*" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" />
-  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.*" />
   </ItemGroup>
 
   <!-- README.md is included via .nuspec or PackageReadmeFile, not needed here for dotnet pack. -->

--- a/Softalleys.Utilities.Queries/README.md
+++ b/Softalleys.Utilities.Queries/README.md
@@ -1,6 +1,6 @@
 # Softalleys.Utilities.Queries
 
-Lightweight CQRS query dispatcher with proper DI lifetimes (Scoped by default, opt-in Singleton) and streaming support for .NET 8 and .NET 9.
+Lightweight CQRS query dispatcher with proper DI lifetimes (Scoped by default, opt-in Singleton) and streaming support for .NET 8, .NET 9, and .NET 10.
 
 ## Features
 

--- a/Softalleys.Utilities.Queries/Softalleys.Utilities.Queries.csproj
+++ b/Softalleys.Utilities.Queries/Softalleys.Utilities.Queries.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -23,6 +23,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Softalleys.Utilities/README.md
+++ b/Softalleys.Utilities/README.md
@@ -1,6 +1,6 @@
 # Softalleys.Utilities
 
-A comprehensive collection of utility classes, extension methods, and validation attributes for .NET applications.
+A comprehensive collection of utility classes, extension methods, and validation attributes for .NET applications with builds targeting .NET 8, .NET 9, and .NET 10.
 
 ## Installation
 

--- a/Softalleys.Utilities/Softalleys.Utilities.csproj
+++ b/Softalleys.Utilities/Softalleys.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -41,6 +41,14 @@
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.*"/>
         <PackageReference Include="Microsoft.AspNetCore.OData" Version="9.*"/>
         <PackageReference Include="System.Formats.Cbor" Version="9.*"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.*"/>
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.*"/>
+        <PackageReference Include="Microsoft.AspNetCore.OData" Version="10.*"/>
+        <PackageReference Include="System.Formats.Cbor" Version="10.*"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- target net10.0 in the core Utilities, Commands, Events, and Queries libraries
- reference the Microsoft.Extensions and ASP.NET Core packages at the 10.* floating versions when building for net10.0
- refresh each package README to advertise .NET 8/9/10 compatibility

## Testing
- not run (dotnet 10 SDK not yet available in the environment)

------
https://chatgpt.com/codex/tasks/task_e_6906a1584b748322a00ed24acb401775